### PR TITLE
Allows custom args for image magick, with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,84 @@ appIcons: {
 }
 ```
 
+
+Advanced Configuration
+----------------------
+
+Additional arguments may be passed to the `convert` command as needed as an array or function. The `%size%` placeholder is interpolated with the `wxh` dimensions of the icon being processed. For example, to apply a scalable overlay to the icons (where 120x120 is the size of the SVG):
+
+```js
+appIcons: {
+  mobile_beta: {
+    src: 'src/icon/app-icon.png',
+    dest: 'src/icon/',
+    options: {
+      createDirectories: true,
+      type: ['ios', 'android'],
+      args: [
+        '-background', 'none',
+        '-size', '120x120',
+        'src/icon/app-icon-beta-overlay.svg',
+        '-resize', '%size%',
+        '-composite'
+      ]
+    }
+  }
+}
+```
+
+Similarly, to create rounded corners on Android:
+
+```js
+appIcons: {
+  mobile_beta: {
+    src: 'src/icon/app-icon.png',
+    dest: 'src/icon/',
+    options: {
+      createDirectories: true,
+      type: ['android'],
+      args: function (size) {
+        if (size) {
+          var dimensions = size.split('x');
+          var cornerRadius = Math.round(100 * dimensions[0] * 20 / 114) / 100;
+
+          return [
+            // Create a 1px transparent border around the image to improve
+            // antialiasing
+            '(',
+              '-size', '%size%',
+              'xc:none',
+              '-draw', 'fill white rectangle 1,1 ' + (dimensions[0] - 2) + ',' + (dimensions[1] - 2),
+            ')',
+            '-compose', 'CopyOpacity',
+            '-composite',
+
+            // Mask off the four corners
+            '(',
+              '+clone',
+              '-alpha', 'extract',
+              '-draw', 'fill black rectangle 1,1 ' + cornerRadius + ',' + cornerRadius + ' fill white circle ' + cornerRadius + ',' + cornerRadius + ' ' + cornerRadius + ',1',
+              '(',
+                '+clone', '-flip',
+              ')', '-compose', 'Multiply', '-composite',
+              '(',
+                '+clone', '-flop',
+              ')', '-compose', 'Multiply', '-composite',
+            ')',
+            '-alpha', 'off',
+            '-compose', 'CopyOpacity',
+            '-composite'
+          ];
+        }
+        return [];
+      }
+    }
+  }
+}
+```
+
+Note that the favicon type does not support size interpolation and uses a significantly different convert command than the other icons that are simple resize operations.
+
 Html
 ----
 

--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -13,7 +13,8 @@ module.exports = function ( grunt ) {
       type: [], // all, favicon, touch, ios, android
       createDirectories: false,
       precomposed: true,
-      precomposedString: '-precomposed'
+      precomposedString: '-precomposed',
+      args: []
     } );
 
     var remaining = this.files.length;
@@ -55,7 +56,18 @@ module.exports = function ( grunt ) {
                     if ( options.precomposed ) {
                       iconName = iconName.replace( /%precomposed%/g, options.precomposedString );
                     }
-                    var args = [image].concat( iconOptions.args ).concat( [iconFolder + iconName] );
+                    var iconArgs = iconOptions.args || [];
+                    var taskArgs = options.args || [];
+                    if ( typeof taskArgs === 'function' ) {
+                      taskArgs = taskArgs( iconOptions.resize );
+                    }
+                    if ( iconOptions.resize ) {
+                      iconArgs = ['-resize', iconOptions.resize].concat( iconArgs );
+                      taskArgs = taskArgs.map( function( arg ) {
+                        return arg.replace( /%size%/g, iconOptions.resize );
+                      } );
+                    }
+                    var args = [image].concat( iconArgs ).concat( taskArgs ).concat( [iconFolder + iconName] );
                     im.convert( args, function ( error ) {
                       if ( error ) {
                         grunt.log.errorlns( error );
@@ -96,36 +108,36 @@ module.exports = function ( grunt ) {
 
   var icons = {
     ios: [
-      {name: 'icon-60.png', args: ['-resize', '60x60']},
-      {name: 'icon-60@2x.png', args: ['-resize', '120x120']},
-      {name: 'icon-76.png', args: ['-resize', '76x76']},
-      {name: 'icon-76@2x.png', args: ['-resize', '152x152']},
-      {name: 'icon-40.png', args: ['-resize', '40x40']},
-      {name: 'icon-40@2x.png', args: ['-resize', '80x80']},
-      {name: 'icon.png', args: ['-resize', '57x57']},
-      {name: 'icon@2x.png', args: ['-resize', '114x114']},
-      {name: 'icon-72.png', args: ['-resize', '72x72']},
-      {name: 'icon-72@2x.png', args: ['-resize', '144x144']},
-      {name: 'icon-small.png', args: ['-resize', '29x29']},
-      {name: 'icon-small@2x.png', args: ['-resize', '58x58']},
-      {name: 'icon-50.png', args: ['-resize', '50x50']},
-      {name: 'icon-50@2x.png', args: ['-resize', '100x100']}
+      {name: 'icon-60.png', resize: '60x60'},
+      {name: 'icon-60@2x.png', resize: '120x120'},
+      {name: 'icon-76.png', resize: '76x76'},
+      {name: 'icon-76@2x.png', resize: '152x152'},
+      {name: 'icon-40.png', resize: '40x40'},
+      {name: 'icon-40@2x.png', resize: '80x80'},
+      {name: 'icon.png', resize: '57x57'},
+      {name: 'icon@2x.png', resize: '114x114'},
+      {name: 'icon-72.png', resize: '72x72'},
+      {name: 'icon-72@2x.png', resize: '144x144'},
+      {name: 'icon-small.png', resize: '29x29'},
+      {name: 'icon-small@2x.png', resize: '58x58'},
+      {name: 'icon-50.png', resize: '50x50'},
+      {name: 'icon-50@2x.png', resize: '100x100'}
     ],
     android: [
-      {name: 'icon-ldpi.png', args: ['-resize', '36x36']},
-      {name: 'icon-mdpi.png', args: ['-resize', '48x48']},
-      {name: 'icon-hdpi.png', args: ['-resize', '72x72']},
-      {name: 'icon-xhdpi.png', args: ['-resize', '96x96']},
-      {name: 'icon-xxhdpi.png', args: ['-resize', '144x144']},
-      {name: 'icon-xxxhdpi.png', args: ['-resize', '192x192']}
+      {name: 'icon-ldpi.png', resize: '36x36'},
+      {name: 'icon-mdpi.png', resize: '48x48'},
+      {name: 'icon-hdpi.png', resize: '72x72'},
+      {name: 'icon-xhdpi.png', resize: '96x96'},
+      {name: 'icon-xxhdpi.png', resize: '144x144'},
+      {name: 'icon-xxxhdpi.png', resize: '192x192'}
     ],
     androidDirectories: [
-      {name: 'drawable-ldpi/icon.png', args: ['-resize', '36x36']},
-      {name: 'drawable-mdpi/icon.png', args: ['-resize', '48x48']},
-      {name: 'drawable-hdpi/icon.png', args: ['-resize', '72x72']},
-      {name: 'drawable-xhdpi/icon.png', args: ['-resize', '96x96']},
-      {name: 'drawable-xxhdpi/icon.png', args: ['-resize', '144x144']},
-      {name: 'drawable-xxxhdpi/icon.png', args: ['-resize', '192x192']}
+      {name: 'drawable-ldpi/icon.png', resize: '36x36'},
+      {name: 'drawable-mdpi/icon.png', resize: '48x48'},
+      {name: 'drawable-hdpi/icon.png', resize: '72x72'},
+      {name: 'drawable-xhdpi/icon.png', resize: '96x96'},
+      {name: 'drawable-xxhdpi/icon.png', resize: '144x144'},
+      {name: 'drawable-xxxhdpi/icon.png', resize: '192x192'}
     ],
     favicon: [
       {
@@ -144,13 +156,13 @@ module.exports = function ( grunt ) {
       }
     ],
     touch: [
-      {name: 'apple-touch-icon%precomposed%.png', args: ['-resize', '57x57']},
-      {name: 'apple-touch-icon-76x76%precomposed%.png', args: ['-resize', '76x76']},
-      {name: 'apple-touch-icon-120x120%precomposed%.png', args: ['-resize', '120x120']},
-      {name: 'apple-touch-icon-152x152%precomposed%.png', args: ['-resize', '152x152']},
-      {name: 'apple-touch-icon-180x180%precomposed%.png', args: ['-resize', '180x180']},
-      {name: 'touch-icon-128x128.png', args: ['-resize', '128x128']},
-      {name: 'touch-icon-192x192.png', args: ['-resize', '192x192']}
+      {name: 'apple-touch-icon%precomposed%.png', resize: '57x57'},
+      {name: 'apple-touch-icon-76x76%precomposed%.png', resize: '76x76'},
+      {name: 'apple-touch-icon-120x120%precomposed%.png', resize: '120x120'},
+      {name: 'apple-touch-icon-152x152%precomposed%.png', resize: '152x152'},
+      {name: 'apple-touch-icon-180x180%precomposed%.png', resize: '180x180'},
+      {name: 'touch-icon-128x128.png', resize: '128x128'},
+      {name: 'touch-icon-192x192.png', resize: '192x192'}
     ]
   };
 


### PR DESCRIPTION
This project is so helpful, very well done! While I was able to get everything I needed for our production iOS and Android apps, we like to use a "BETA" sash over the corner of app icons for our testing releases. Since image magick is so flexible, the most straightforward way to allow compositing an image over the icon was to simply support additional args passed to convert.

The custom args can be specified as an array, or a function that returns an array. Interpolation of `%size%` allows the size to be repeated throughout the args.

I added two examples to the README that should be helpful for others. The rounded corners for Android is particularly useful for folks who want a single icon to look the same on both platforms.

Applying both examples to a rectangle icon suitable for iOS with a simple BETA overlay image yields the following:

![sample icon](https://cloud.githubusercontent.com/assets/507058/7992319/7e2715e6-0acc-11e5-9b77-b578e7bbd184.png)

Would you like me to submit a pull request adding rounded corners as a built-in option? I think it could be useful for some of the output types.
