### PR TITLE
feat: add mkdirp to create path folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "grunt": "~0.4.0"
   },
   "dependencies": {
-    "imagemagick": "0.1.x"
+    "imagemagick": "0.1.x",
+    "mkdirp": "^0.5.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -3,6 +3,7 @@ module.exports = function ( grunt ) {
 
   var fs = require( 'fs' );
   var path = require( 'path' );
+  var mkdirp = require( 'mkdirp' );
 
   grunt.registerMultiTask( 'appIcons', 'create app icons', function () {
 
@@ -26,6 +27,11 @@ module.exports = function ( grunt ) {
         var image = file.src[0];
         var folder = path.dirname( file.dest ) + '/' + path.basename( file.dest ) + '/';
         var folders = [folder];
+
+        // Create path folders, if needed
+        mkdirp(path.dirname( file.dest ), function ( error ) {
+          grunt.log.error( error );
+        });
 
         if ( options.type.indexOf( 'all' ) >= 0 ) {
           options.type = ['favicon', 'touch', 'ios', 'android']


### PR DESCRIPTION
If the target folder doesn't exist, this task will break.
I added mkdirp in order to create every folder in the path.
