### PR TITLE
fix: remove border options from .ico file

### DIFF
--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -143,8 +143,6 @@ module.exports = function ( grunt ) {
       {
         name: 'favicon.ico',
         args: [
-          '-bordercolor', 'white',
-          '-border', '0',
           '(', '-clone', '0', '-resize', '16x16', ')',
           '(', '-clone', '0', '-resize', '32x32', ')',
           '(', '-clone', '0', '-resize', '48x48', ')',


### PR DESCRIPTION
border and background paramters for .ico files preventing
transparent backgrounds for converted .png to .ico. Removing
that will fix this.
