### PR TITLE
iOS icon revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ appIcons: {
     src: 'src/icon/app-icon.png',
     dest: 'www/',
     options: {
-      type: ['touch', 'favicon'] // android, ios
+      type: ['touch', 'favicon'] // android, ios, ios6
     }
   }
 }
 ```
+
+Note that the `ios` type no longer includes icons that are required only for iOS 6 and earlier. For apps that support earlier versions of iOS, be sure to include both the `ios` and `ios6` types, otherwise icons will only be generated for iOS 7 and newer.
 
 
 Advanced Configuration
@@ -58,7 +60,7 @@ appIcons: {
     dest: 'src/icon/',
     options: {
       createDirectories: true,
-      type: ['ios', 'android'],
+      type: ['ios', 'ios6', 'android'],
       args: [
         '-background', 'none',
         '-size', '120x120',

--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -34,7 +34,7 @@ module.exports = function ( grunt ) {
         });
 
         if ( options.type.indexOf( 'all' ) >= 0 ) {
-          options.type = ['favicon', 'touch', 'ios', 'android']
+          options.type = ['favicon', 'touch', 'ios', 'ios6', 'android']
         }
 
         if ( options.createDirectories ) {

--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -124,8 +124,8 @@ module.exports = function ( grunt ) {
       {name: 'Icon-Small.png', resize: '29x29'},
       {name: 'Icon-Small@2x.png', resize: '58x58'},
       {name: 'Icon-Small@3x.png', resize: '87x87'},
-      
-      // iOS 6 only
+    ],
+    ios6: [
       {name: 'Icon.png', resize: '57x57'},
       {name: 'Icon@2x.png', resize: '114x114'},
       {name: 'Icon-72.png', resize: '72x72'},

--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -114,21 +114,24 @@ module.exports = function ( grunt ) {
 
   var icons = {
     ios: [
-      {name: 'icon-60.png', resize: '60x60'},
-      {name: 'icon-60@2x.png', resize: '120x120'},
-      {name: 'icon-60@3x.png', resize: '180x180'},
-      {name: 'icon-76.png', resize: '76x76'},
-      {name: 'icon-76@2x.png', resize: '152x152'},
-      {name: 'icon-40.png', resize: '40x40'},
-      {name: 'icon-40@2x.png', resize: '80x80'},
-      {name: 'icon.png', resize: '57x57'},
-      {name: 'icon@2x.png', resize: '114x114'},
-      {name: 'icon-72.png', resize: '72x72'},
-      {name: 'icon-72@2x.png', resize: '144x144'},
-      {name: 'icon-small.png', resize: '29x29'},
-      {name: 'icon-small@2x.png', resize: '58x58'},
-      {name: 'icon-50.png', resize: '50x50'},
-      {name: 'icon-50@2x.png', resize: '100x100'}
+      {name: 'Icon-60@2x.png', resize: '120x120'},
+      {name: 'Icon-60@3x.png', resize: '180x180'},
+      {name: 'Icon-76.png', resize: '76x76'},
+      {name: 'Icon-76@2x.png', resize: '152x152'},
+      {name: 'Icon-Small-40.png', resize: '40x40'},
+      {name: 'Icon-Small-40@2x.png', resize: '80x80'},
+      {name: 'Icon-Small-40@3x.png', resize: '120x120'},
+      {name: 'Icon-Small.png', resize: '29x29'},
+      {name: 'Icon-Small@2x.png', resize: '58x58'},
+      {name: 'Icon-Small@3x.png', resize: '87x87'},
+      
+      // iOS 6 only
+      {name: 'Icon.png', resize: '57x57'},
+      {name: 'Icon@2x.png', resize: '114x114'},
+      {name: 'Icon-72.png', resize: '72x72'},
+      {name: 'Icon-72@2x.png', resize: '144x144'},
+      {name: 'Icon-Small-50.png', resize: '50x50'},
+      {name: 'Icon-Small-50@2x.png', resize: '100x100'}
     ],
     android: [
       {name: 'icon-ldpi.png', resize: '36x36'},


### PR DESCRIPTION
This introduces some changes to the naming scheme of iOS icons to better match the recommendations set out by Apple in [Technical QA1686](https://developer.apple.com/library/ios/qa/qa1686/_index.html). It also introduces a sunset to iOS 6 icons, relegating them to a separate `ios6` type allowing modern apps to include only iOS7+ compatible assets. 

The README has been updated to reflect these changes. If acceptable, please publish as a minor version update (1.1.0) due to the backwards compatibility issues introduced here.
### Added
- `Icon-Small-40@3x.png` for iPhone 6 Plus
### Removed
- `icon-60.png` only Retina iPhones are able to run iOS 7+ so this size is not needed
