### PR TITLE
Fixes "convert: unable to open image" error due to race condition

### DIFF
--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -29,9 +29,7 @@ module.exports = function ( grunt ) {
         var folders = [folder];
 
         // Create path folders, if needed
-        mkdirp(path.dirname( file.dest ), function ( error ) {
-          grunt.log.error( error );
-        });
+        mkdirp.sync(path.dirname( file.dest ));
 
         if ( options.type.indexOf( 'all' ) >= 0 ) {
           options.type = ['favicon', 'touch', 'ios', 'android']


### PR DESCRIPTION
Since `mkdirp` is asynchronous, in some situations the parent directories may not have been created by the time the task attempts to create icons in them. This results in an error `convert: unable to open image`.

The change simply uses the synchronous mode of `mkdirp` to ensure that the directory is created before moving forward.
