### PR TITLE
Added iosStore, playStore, amazonStore icon types.

### DIFF
--- a/tasks/tc-app-icons.js
+++ b/tasks/tc-app-icons.js
@@ -146,6 +146,17 @@ module.exports = function ( grunt ) {
       {name: 'drawable-xxhdpi/icon.png', resize: '144x144'},
       {name: 'drawable-xxxhdpi/icon.png', resize: '192x192'}
     ],
+    iosStore: [
+      {name: 'iTunesArtwork.png', resize: '512x512'},
+      {name: 'iTunesArtwork@2x.png', resize: '1024x1024'}
+    ],
+    playStore: [
+      {name: 'icon-google-play.png', resize: '512x512'}
+    ],
+    amazonStore: [
+      {name: 'icon-amazon-small.png', resize: '114x114'},
+      {name: 'icon-amazon-large.png', resize: '512x512'}
+    ],
     favicon: [
       {
         name: 'favicon.ico',


### PR DESCRIPTION
This adds a few additional icon sizes that are required for each of the Apple App Store, Google Play, and Amazon Appstore. I have not added these to the `all` type yet since that would conflict with changes in a pending pull request. Happy to rebase after #7 is merged then add these as defaults.

This gets particularly useful when imagemagick effects like rounded corners are added to icons, since while the source image may be big enough (e.g. 1024x1024) to quickly scale down for Amazon or Google Play, the styling will not match unless it is run through with the same settings as the app icons.

Any suggestions on icon and type naming? The current, rather arbitrary type and image names are:

``` yaml
iosStore:
- iTunesArtwork.png
- iTunesArtwork@2x.png

playStore:
- icon-google-play.png

amazonStore:
- icon-amazon-small.png
- icon-amazon-large.png
```
